### PR TITLE
Fix issue where gtag wasn't firing for client demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,15 @@ Edit `_Host.cshtml` and apply the following change:
 +   <script src="_content/Blazor-Analytics/blazor-analytics.js"></script>
 ```
 
+### WASM Specific Configuration
+
+Edit `index.html` and apply the following change:
+
+```diff
+    <script src="_framework/blazor.webassembly.js"></script>
++   <script src="_content/Blazor-Analytics/blazor-analytics.js"></script>
+```
+
 
 # Changelog
 ### v3.0.0

--- a/demo/DemoApp/DemoApp.Client/wwwroot/index.html
+++ b/demo/DemoApp/DemoApp.Client/wwwroot/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+﻿<!DOCTYPE html>
 <html>
 <head>
     <meta charset="utf-8" />
@@ -12,5 +12,6 @@
     <app>Loading...</app>
 
     <script src="_framework/blazor.webassembly.js"></script>
+    <script src="_content/Blazor-Analytics/blazor-analytics.js"></script>
 </body>
 </html>


### PR DESCRIPTION
Add reference to blazor-analytics.js for Client demo in index.html and update README.