### PR TITLE
Issue #31 : Fixed order of arguments to TrackEvent method

### DIFF
--- a/demo/DemoApp/DemoApp.Client/Pages/Counter.razor
+++ b/demo/DemoApp/DemoApp.Client/Pages/Counter.razor
@@ -15,6 +15,6 @@
     private void IncrementCount()
     {
         currentCount++;
-        Analytics.TrackEvent("Increment", currentCount.ToString(), "CountPage");
+        Analytics.TrackEvent("Increment", currentCount,  "CountPage");
     }
 }

--- a/demo/DemoApp/DemoApp.Server/Pages/Counter.razor
+++ b/demo/DemoApp/DemoApp.Server/Pages/Counter.razor
@@ -15,6 +15,6 @@
     private void IncrementCount()
     {
         currentCount++;
-        Analytics.TrackEvent("Increment", currentCount.ToString(), "CountPage");
+        Analytics.TrackEvent("Increment", currentCount, "CountPage");
     }
 }

--- a/src/Blazor.Analytics/Abstractions/IAnalytics.cs
+++ b/src/Blazor.Analytics/Abstractions/IAnalytics.cs
@@ -8,6 +8,7 @@ namespace Blazor.Analytics
 
         Task TrackNavigation(string uri);
 
-        Task TrackEvent(string eventName, string eventValue, string eventCategory = null);
+        Task TrackEvent(string eventName, string eventCategory = null, string eventLabel = null, int? eventValue = null);
+        Task TrackEvent(string eventName, int eventValue, string eventCategory = null, string eventLabel = null);
     }
 }

--- a/src/Blazor.Analytics/Components/NavigationTracker.razor
+++ b/src/Blazor.Analytics/Components/NavigationTracker.razor
@@ -1,5 +1,4 @@
-﻿@using System
-@using System.Threading.Tasks
+﻿@using System.Threading.Tasks
 @using Microsoft.AspNetCore.Components
 @using Microsoft.AspNetCore.Components.Routing
 

--- a/src/Blazor.Analytics/GoogleAnalytics/GoogleAnalyticsStrategy.cs
+++ b/src/Blazor.Analytics/GoogleAnalytics/GoogleAnalyticsStrategy.cs
@@ -52,8 +52,9 @@ namespace Blazor.Analytics.GoogleAnalytics
 
         public async Task TrackEvent(
             string eventName,
-            string eventValue,
-            string eventCategory = null)
+            string eventCategory = null,
+            string eventLabel = null,
+            int? eventValue = null)
         {
             if (!_isInitialized)
             {
@@ -62,7 +63,12 @@ namespace Blazor.Analytics.GoogleAnalytics
 
             await _jsRuntime.InvokeAsync<string>(
                 GoogleAnalyticsInterop.TrackEvent,
-                _trackingId, eventName, eventValue, eventCategory);
+                eventName, eventCategory, eventLabel, eventValue);
+        }
+
+        public Task TrackEvent(string eventName, int eventValue, string eventCategory = null, string eventLabel = null)
+        {
+            return TrackEvent (eventName, eventCategory, eventLabel, eventValue);
         }
     }
 }

--- a/src/Blazor.Analytics/GoogleAnalytics/Resources/GoogleAnalyticsInterop.ts
+++ b/src/Blazor.Analytics/GoogleAnalytics/Resources/GoogleAnalyticsInterop.ts
@@ -43,11 +43,11 @@ namespace GoogleAnalyticsInterop
         }
     }
 
-    export function trackEvent(event: string, eventCategory: string, eventLabel: string, eventValue: string)
+    export function trackEvent(eventName: string, eventCategory: string, eventLabel: string, eventValue: string)
     {
-        gtag("event", event, { event_category: eventCategory, event_label: eventLabel, value: eventValue });
+        gtag("event", eventName, { event_category: eventCategory, event_label: eventLabel, value: eventValue });
         if(this.debug){
-            console.log(`[GTAG][Event trigered]: ${event}`);
+            console.log(`[GTAG][Event triggered]: ${eventName}`);
         }
     }
 }


### PR DESCRIPTION
Changed order of parameters for TrackEvent.
Can now use:  
`TrackEvent(eventName, eventCategory, eventLabel, eventValue)` where only first parameter is mandatory,
or:
`TrackEvent(eventName, eventValue, eventCategory, eventLabel)` where first two parameters are mandatory.

Note: I have changed `eventValue` to be an `int`, since that is what GA is expecting.