### PR TITLE
Fix duplicate pageview tracking.

### DIFF
--- a/src/Blazor.Analytics/GoogleAnalytics/Resources/GoogleAnalyticsInterop.ts
+++ b/src/Blazor.Analytics/GoogleAnalytics/Resources/GoogleAnalyticsInterop.ts
@@ -27,7 +27,7 @@ namespace GoogleAnalyticsInterop
 
         document.head.appendChild(script);
 
-        gtag("config", trackingId);
+        gtag("config", trackingId, { 'send_page_view': false });
 
         if(this.debug){
             console.log(`[GTAG][${trackingId}] Configured!`);


### PR DESCRIPTION
New PR from rebased fork.
I'm not a GA expert, but it seems that duplicate pageview hits are being sent to Google Analytics when requesting a page (but not when navigating in the loaded app).
Steps to reproduce: Refresh the page in browser and you will see two requests being made to Google Analytics.
I guess this is because a pageview hit is being sent automatically when gtag is added to the page, and then a pageview hit is being sent in NavigationTracker.razor on first render.
This fix configures gtag to not send pageview hit when added. See also https://developers.google.com/analytics/devguides/collection/gtagjs#disable_pageview_measurement.