### PR TITLE
Catch interop undefined error instead of having application crash

### DIFF
--- a/src/Blazor.Analytics/Components/NavigationTracker.razor
+++ b/src/Blazor.Analytics/Components/NavigationTracker.razor
@@ -16,16 +16,12 @@
 
     protected override async Task OnInitializedAsync()
     {
-        await base.OnInitializedAsync();
-
         NavigationManager.LocationChanged -= OnLocationChanged;
         NavigationManager.LocationChanged += OnLocationChanged;
     }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
-        await base.OnAfterRenderAsync(firstRender);
-
         if (firstRender)
         {
             // Track initial navigation

--- a/src/Blazor.Analytics/Components/NavigationTracker.razor
+++ b/src/Blazor.Analytics/Components/NavigationTracker.razor
@@ -3,6 +3,8 @@
 @using Microsoft.AspNetCore.Components.Routing
 @using Blazor.Analytics.Abstractions
 
+@implements IDisposable
+
 @code
 {
     [Inject]

--- a/src/Blazor.Analytics/Components/NavigationTracker.razor
+++ b/src/Blazor.Analytics/Components/NavigationTracker.razor
@@ -16,7 +16,6 @@
 
     protected override async Task OnInitializedAsync()
     {
-        NavigationManager.LocationChanged -= OnLocationChanged;
         NavigationManager.LocationChanged += OnLocationChanged;
     }
 

--- a/src/Blazor.Analytics/Components/NavigationTracker.razor
+++ b/src/Blazor.Analytics/Components/NavigationTracker.razor
@@ -16,7 +16,7 @@
     [Inject]
     protected ITrackingNavigationState TrackingNavigationState { get; set; } = null;
 
-    protected override async Task OnInitializedAsync()
+    protected override void OnInitialized()
     {
         NavigationManager.LocationChanged += OnLocationChanged;
     }

--- a/src/Blazor.Analytics/GoogleAnalytics/GoogleAnalyticsStrategy.cs
+++ b/src/Blazor.Analytics/GoogleAnalytics/GoogleAnalyticsStrategy.cs
@@ -63,7 +63,7 @@ namespace Blazor.Analytics.GoogleAnalytics
             }
         }
 
-        public async Task ConfigureGlobalEventData(Dictionary<string, object> globalEventData)
+        public void ConfigureGlobalEventData(Dictionary<string, object> globalEventData)
         {
             this._globalEventData = globalEventData;
         }

--- a/src/Blazor.Analytics/GoogleAnalytics/GoogleAnalyticsStrategy.cs
+++ b/src/Blazor.Analytics/GoogleAnalytics/GoogleAnalyticsStrategy.cs
@@ -17,7 +17,8 @@ namespace Blazor.Analytics.GoogleAnalytics
         private Dictionary<string, object> _globalEventData = new Dictionary<string, object>();
         private bool _isInitialized = false;
         private bool _debug = false;
-
+        private bool _interopError = false;
+        
         public GoogleAnalyticsStrategy(
             IJSRuntime jsRuntime
         )
@@ -38,8 +39,16 @@ namespace Blazor.Analytics.GoogleAnalytics
                 throw new InvalidOperationException("Invalid TrackingId");
             }
 
-            await _jsRuntime.InvokeAsync<string>(
-                GoogleAnalyticsInterop.Configure, _trackingId, _globalConfigData, _debug);
+            try
+            {
+                await _jsRuntime.InvokeAsync<string>(
+                    GoogleAnalyticsInterop.Configure, _trackingId, _globalConfigData, _debug);
+            }
+            catch (JSException)
+            {
+                _interopError = true;
+                Disable();
+            }
             
             _isInitialized = true;
         }
@@ -71,8 +80,21 @@ namespace Blazor.Analytics.GoogleAnalytics
                 await Initialize();
             }
 
-            await _jsRuntime.InvokeAsync<string>(
-                GoogleAnalyticsInterop.Navigate, _trackingId, uri);
+            if (_interopError)
+            {
+                return;
+            }
+
+            try
+            {
+                await _jsRuntime.InvokeAsync<string>(
+                    GoogleAnalyticsInterop.Navigate, _trackingId, uri);
+            }
+            catch (JSException)
+            {
+                _interopError = true;
+                Disable();
+            }
         }
 
         public async Task TrackEvent(
@@ -106,12 +128,31 @@ namespace Blazor.Analytics.GoogleAnalytics
                 await Initialize();
             }
 
-            await _jsRuntime.InvokeAsync<string>(
-                GoogleAnalyticsInterop.TrackEvent,
-                eventName, eventData, _globalEventData);
+            if (_interopError)
+            {
+                return;
+            }
+
+            try
+            {
+                await _jsRuntime.InvokeAsync<string>(
+                    GoogleAnalyticsInterop.TrackEvent,
+                    eventName, eventData, _globalEventData);
+            }
+            catch (JSException)
+            {
+                _interopError = true;
+                Disable();
+            }
         }
 
-        public void Enable() => _isGloballyEnabledTracking = true;
+        public void Enable()
+        {
+            if (_interopError) 
+                return;
+
+            _isGloballyEnabledTracking = true;
+        }
 
         public void Disable() => _isGloballyEnabledTracking = false;
     }


### PR DESCRIPTION
Closes #55

The changes this PR makes:

1. In `GoogleAnalyticsStrategy.cs`, a new boolean is added called `_interopError`. This is set whenever a `JSException` is caught during an interop call. In our application, this has been failing from the `GoogleAnalyticsInterop` JS namespace being undefined, which we assume is related to #55. Out of an abundance of caution, the try-catch statements now wrap all interop calls. If an error is ever caught, it then disables that tracking until the application is refreshed.
2. In `GoogleAnalyticsStrategy.cs`, `ConfigureGlobalEventData` was marked as `async` but awaited nothing, so this was changed to synchronous.
3. In `NavigationTracker.razor`, there were calls to `base.OnInitializedAsync()` and `base.OnAfterRenderAsync()` which were unnecessary and removed.
4. In `NavigationTracker.razor`, initialization was done through `OnInitializedAsync()` but no async work was being done, so this was changed to use `OnInitialized()` instead.
5. In `NavigationTracker.razor`, there was an unsubscribe happening during initialization, and a `Dispose` method that wasn't being used because the component never declared that it implemented `IDisposable`. That unsubscribe was removed from the initialization method, and the component now implements `IDisposable`, so desubscription now occurs on component disposal.