### PR TITLE
Fix .NET 10 preview compatibility issues

### DIFF
--- a/src/Blazor.Analytics/Blazor.Analytics.csproj
+++ b/src/Blazor.Analytics/Blazor.Analytics.csproj
@@ -26,12 +26,15 @@
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <RepositoryType>git</RepositoryType>
         <Copyright>Ivan Sanz Carasa (isc30)</Copyright>
+        
+        <!-- Static Web Assets Configuration for .NET 8+ compatibility -->
+        <StaticWebAssetProjectMode>Default</StaticWebAssetProjectMode>
     </PropertyGroup>
 
     <ItemGroup>
         <PackageReference Include="Microsoft.AspNetCore.Components" Version="3.1.8" />
         <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="3.1.8" />
-        <PackageReference Include="GitVersionTask" Version="5.3.7">
+        <PackageReference Include="GitVersion.MsBuild" Version="6.3.0">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
@@ -50,6 +53,17 @@
 		<Content Update="tsconfig.json">
 			<Pack>false</Pack>
 		</Content>
+	</ItemGroup>
+
+	<!-- Static Web Assets Configuration -->
+	<ItemGroup>
+		<StaticWebAsset Include="wwwroot/blazor-analytics.js" Condition="Exists('wwwroot/blazor-analytics.js')">
+			<SourceType>Discovered</SourceType>
+			<SourceId>$(PackageId)</SourceId>
+			<ContentRoot>$(MSBuildProjectDirectory)/wwwroot</ContentRoot>
+			<BasePath>_content/$(PackageId)</BasePath>
+			<RelativePath>blazor-analytics.js</RelativePath>
+		</StaticWebAsset>
 	</ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- Fixes ApplyCompressionNegotiation task failure when building with .NET 10 preview
- Adds proper static web assets configuration for modern .NET versions
- Updates GitVersion to latest version compatible with .NET 10

## Changes Made
- Add `StaticWebAssetProjectMode` configuration for .NET 8+ compatibility
- Configure explicit `StaticWebAsset` for blazor-analytics.js inclusion
- Upgrade from deprecated `GitVersionTask 5.3.7` to `GitVersion.MsBuild 6.3.0`
- Update GitVersion.yml configuration format for version 6.x compatibility
- Replace `tag` with `label` and update `prevent-increment` syntax

## Test Plan
- [x] Build succeeds with .NET 10 preview
- [x] NuGet package creation works without errors
- [x] Static web assets properly included in package (`staticwebassets/blazor-analytics.js`)
- [x] GitVersion generates correct version numbers

Resolves the issue reported where endpoints were not found for the static web asset `blazor-analytics.js` when using .NET 10 preview.